### PR TITLE
Add signup page route and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Node dependencies
+node_modules/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS files
+.DS_Store
+
+# Env files
+.env
+

--- a/App.js
+++ b/App.js
@@ -8,6 +8,7 @@ import Profile from "./pages/Profile/Profile";
 import Econ from "./pages/Econ/Econ";
 import Timeline from "./pages/Timeline/Timeline";
 import Settings from "./pages/Settings/Settings";
+import SignUp from "./pages/SignUp/SignUp";
 import NotFound from "./pages/NotFound/NotFound"; // Ensure this path is correct
 
 const App = () => {
@@ -20,6 +21,7 @@ const App = () => {
         <Route path="econ" element={<Econ />} />
         <Route path="profile" element={<Profile />} />
         <Route path="timeline" element={<Timeline />} />
+        <Route path="signup" element={<SignUp />} />
         <Route path="settings" element={<Settings />} />
         {/* Add more routes here as needed */}
         <Route path="*" element={<NotFound />} /> {/* Catch-all route */}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Singularity React App
+
+This project contains a React front-end with an Express backend. It requires Node.js and npm.
+
+## Getting Started
+
+1. Install dependencies
+
+```bash
+npm install
+```
+
+2. Start the development server
+
+```bash
+npm start
+```
+
+Backend scripts can be run with:
+
+```bash
+node server.js
+```
+
+## Available Pages
+
+- `/` - Home page
+- `/ping` - Example chat page
+- `/econ` - Economics dashboard
+- `/profile` - User profile
+- `/timeline` - Timeline example
+- `/signup` - Sign up page
+- `/settings` - User settings
+
+## License
+
+This project is provided as-is for demonstration purposes.

--- a/pages/SignUp/SignUp.js
+++ b/pages/SignUp/SignUp.js
@@ -1,0 +1,10 @@
+import React from "react";
+import SignupForm from "../../components/SignupForm";
+
+const SignUp = () => (
+  <div className="signup-page">
+    <SignupForm onClose={() => {}} onSwitchToLogin={() => {}} />
+  </div>
+);
+
+export default SignUp;


### PR DESCRIPTION
## Summary
- add a basic signup page component
- update routing in `App.js` to include the new page
- document how to run the project and list available pages
- ignore node modules and environment files

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fa2a3182c832183760d20a1395527