### PR TITLE
refactor: delegate Index layout to Layout component

### DIFF
--- a/pages/Index/Index.js
+++ b/pages/Index/Index.js
@@ -2,30 +2,19 @@
 import React, { useState } from "react";
 import ContentDisplayer from "./ContentDisplayer";
 import ContentArea from "./ContentArea";
-import RightSidebar from "../../components/RightSidebar";
-import TopBar from "../../components/TopBar";
 
 
 const Index = () => {
   const [contentType, setContentType] = useState("All");
-  const [isRightSidebarVisible, setIsRightSidebarVisible] = useState(true);
 
   const handleContentTypeChange = (type) => {
     setContentType(type);
   };
 
-  const onToggleSidebar = () => {
-    setIsRightSidebarVisible((prev) => !prev);
-  };
-
   return (
     <div className="index-page">
-      <TopBar onToggleSidebar={onToggleSidebar} showUploadButton={false} />
-      <div className={`index-content ${isRightSidebarVisible ? 'with-sidebar' : ''}`}>
-        <ContentDisplayer onContentTypeChange={handleContentTypeChange} />
-        <ContentArea contentType={contentType} />
-      </div>
-      {isRightSidebarVisible && <RightSidebar />}
+      <ContentDisplayer onContentTypeChange={handleContentTypeChange} />
+      <ContentArea contentType={contentType} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove redundant TopBar and layout logic from Index page
- rely on Layout's `<Outlet />` for consistent routing structure

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898f8ef60b88321b637b214ccc094c7